### PR TITLE
Make retry of cluster bootstrap easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 .python-version
 .venv
 kubeconfig
+.vscode
+**/.DS_Store
+
+# Don't track unsealed credentials files
+clusters/*/credentials.y[a]ml
+!clusters/example/credentials.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ kubeconfig
 **/.DS_Store
 
 # Don't track unsealed credentials files
-clusters/*/credentials.y[a]ml
+clusters/*/credentials.yaml
 !clusters/example/credentials.yaml

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ must then be updated with the following information:
   * The OpenStack auth URL and region, which you can get from your cloud admin
   * The ID and secret of the application credential
   * The ID of the target project in OpenStack
-  
+
 During the bootstrap process, this file will be encrypted using
 [kubeseal](https://github.com/bitnami-labs/sealed-secrets) and pushed to the git repository.
 Be careful to **NEVER** commit the unencrypted version.

--- a/bin/manage
+++ b/bin/manage
@@ -593,6 +593,7 @@ async def bootstrap(cluster):
         await wait_for_helm_releases(ek_capi)
         # Seal the cluster credentials using kubeseal
         credentials_path = path / "credentials.yaml"
+        sealed_credentials_path = path / "credentials-sealed.yaml"
         exec(
             "kubeseal",
             "--kubeconfig", kubeconfig_capi,
@@ -600,7 +601,7 @@ async def bootstrap(cluster):
             "--controller-name", "sealed-secrets",
             "--controller-namespace", "sealed-secrets-system",
             "--secret-file", credentials_path,
-            "--sealed-secret-file", credentials_path
+            "--sealed-secret-file", sealed_credentials_path,
         )
         # Commit and push the changes to the remote
         exec("git", "add", path)

--- a/bin/manage
+++ b/bin/manage
@@ -290,7 +290,7 @@ def kind_cluster():
         helm_client = pyhelm3.Client(kubeconfig = kubeconfig.name)
         ek_client = easykube.Configuration.from_kubeconfig(kubeconfig.name).async_client()
 
-        yield helm_client, ek_client
+        yield helm_client, ek_client, kubeconfig.name
 
         # If the task executes without error, tear down the kind cluster
         # If not, we leave it behind for debugging
@@ -399,6 +399,25 @@ async def bootstrap_flux(helm_client):
         wait = True
     )
 
+async def bootstrap_sealed_secrets(ek_client, path, kubeconfig_path):
+    """
+    Boostraps the sealed secrets controller onto the target cluster
+    and adds the cloud credentials as a sealed secret.
+    """
+    await kustomize_install(ek_client, REPO_ROOT / "components" / "sealed-secrets")
+    await wait_for_helm_releases(ek_client)
+    # Seal the cluster credentials using kubeseal
+    credentials_path = path / "credentials.yaml"
+    sealed_credentials_path = path / "credentials-sealed.yaml"
+    exec(
+        "kubeseal",
+        "--kubeconfig", kubeconfig_path,
+        "--format", "yaml",
+        "--controller-name", "sealed-secrets",
+        "--controller-namespace", "sealed-secrets-system",
+        "--secret-file", credentials_path,
+        "--sealed-secret-file", sealed_credentials_path,
+    )
 
 async def kustomize_install(ek_client, path):
     """
@@ -564,9 +583,11 @@ async def bootstrap(cluster):
     """
     path = resolve_cluster(cluster)
 
-    with kind_cluster() as (helm_kind, ek_kind):
+    with kind_cluster() as (helm_kind, ek_kind, kubeconfig_kind):
         # Bootstrap Flux on the kind cluster
         await bootstrap_flux(helm_kind)
+        # Bootstrap the sealed secrets on the kind cluster
+        await bootstrap_sealed_secrets(ek_kind, path, kubeconfig_kind)
         # Install the Flux resources for the CAPI cluster on the kind cluster
         await kustomize_install(ek_kind, path)
         await wait_for_helm_releases(ek_kind)
@@ -588,21 +609,8 @@ async def bootstrap(cluster):
         await move_capi_resources(ek_kind, ek_capi, "capi-self")
         await wait_for_cluster(ek_capi, "capi-self")
         # At this point, the cluster is self-managed
-        # Bootstrap the sealed secrets
-        await kustomize_install(ek_capi, REPO_ROOT / "components" / "sealed-secrets")
-        await wait_for_helm_releases(ek_capi)
-        # Seal the cluster credentials using kubeseal
-        credentials_path = path / "credentials.yaml"
-        sealed_credentials_path = path / "credentials-sealed.yaml"
-        exec(
-            "kubeseal",
-            "--kubeconfig", kubeconfig_capi,
-            "--format", "yaml",
-            "--controller-name", "sealed-secrets",
-            "--controller-namespace", "sealed-secrets-system",
-            "--secret-file", credentials_path,
-            "--sealed-secret-file", sealed_credentials_path,
-        )
+        # Bootstrap the sealed secrets on the CAPI cluster
+        await bootstrap_sealed_secrets(ek_capi, path, kubeconfig_capi)
         # Commit and push the changes to the remote
         exec("git", "add", path)
         exec("git", "commit", "-m", f"Bootstrap cluster - {cluster}")
@@ -657,7 +665,7 @@ async def teardown(cluster):
     kubeconfig_capi = path / "kubeconfig"
     ek_capi = easykube.Configuration.from_kubeconfig(kubeconfig_capi).async_client()
 
-    with kind_cluster() as (helm_kind, ek_kind):
+    with kind_cluster() as (helm_kind, ek_kind, _):
         # Bootstrap Flux on the kind cluster
         await bootstrap_flux(helm_kind)
         # Bootstrap Cluster API on the kind cluster

--- a/clusters/example/kustomization.yaml
+++ b/clusters/example/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - ../../components/cluster-api
   - ../../components/cluster
   - configmap.yaml
-  - credentials.yaml
+  - credentials-sealed.yaml
 
 # Patch the Helm release for the cluster to update the release name
 #   This ensures we get nicely named resources in OpenStack


### PR DESCRIPTION
Avoids overwriting credentials file with sealed secret equivalent so that bootstrap can simply be re-run immediately after a teardown.